### PR TITLE
fix(docs): INA226 Strom-Auflösung — konfigurierbar via CAL-Register, nicht 125 µA/LSB

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -46,12 +46,14 @@ flowchart LR
 
 Beide Rails sind über je einen [INA226](https://www.ti.com/product/INA226) am I²C-Bus messbar:
 
-| Rail | I²C-Adresse | Shunt | Strom-Vollausschlag | Strom-Auflösung |
-| ---- | ----------- | ----- | ------------------- | --------------- |
-| +12V | `0x41` (`0b1000001`) | 10 mΩ | ≈ 8.19 A (V<sub>shunt,max</sub> = 81.92 mV) | 125 µA / LSB |
-| +5V  | `0x40` (`0b1000000`) | 10 mΩ | ≈ 8.19 A | 125 µA / LSB |
+| Rail | I²C-Adresse | Shunt | Strom-Vollausschlag |
+| ---- | ----------- | ----- | ------------------- |
+| +12V | `0x41` (`0b1000001`) | 10 mΩ | ≈ 8.19 A (V<sub>shunt,max</sub> = 81.92 mV) |
+| +5V  | `0x40` (`0b1000000`) | 10 mΩ | ≈ 8.19 A |
 
-Der INA226 liefert pro Adresse Bus-Spannung (in 1.25 mV-Schritten), Shunt-Spannung und einen integrierten Strom-Wert. Konfigurations- und Lese-Beispiele siehe INA226-Datenblatt.
+Der INA226 liefert pro Adresse Bus-Spannung (in 1.25 mV-Schritten), Shunt-Spannung (2.5 µV/LSB) und einen integrierten Strom-Wert.
+
+**Strom-Auflösung ist konfigurierbar** über das CALIBRATION-Register (Treiber-Setup): `Current_LSB = max_expected_current / 32768`. Bei der maximal möglichen Stromtragfähigkeit des 10-mΩ-Shunts (~8.19 A) entspricht das **≈ 250 µA/LSB**. Geringere `Current_LSB`-Werte erhöhen die Auflösung, begrenzen aber den Strommessbereich proportional. Konfigurations-Beispiele siehe INA226-Datenblatt.
 
 ## Bus-Stecker
 


### PR DESCRIPTION
## Summary

Copilot-Review-Befund auf der ursprünglichen PR #6 (L54) — nach Verifikation gegen INA226-Datenblatt bestätigt:

- **125 µA/LSB** war falsch hergeleitet (VShunt-LSB / R_shunt).
- Die INA226 Strom-Register-Auflösung ist **treiberseitig konfigurierbar** via CALIBRATION-Register: `Current_LSB = max_expected_current / 32768`.
- Bei 8 A Vollausschlag → ≈ 250 µA/LSB.
- VShunt-LSB ist 2.5 µV/LSB (signed 16-bit über ±81.92 mV), nicht 1.25 µV.

## Test plan

- [x] Wording technisch korrekt
- [ ] kibot-check passt