### PR TITLE
chore: migrate <<HASH>> placeholder to <<VERSION>>

### DIFF
--- a/PowerBoard.kicad_pcb
+++ b/PowerBoard.kicad_pcb
@@ -14691,7 +14691,7 @@
 			(justify bottom)
 		)
 	)
-	(gr_text "<<HASH>>"
+	(gr_text "<<VERSION>>"
 		(at 144.526 124.841 0)
 		(layer "F.SilkS")
 		(uuid "ce3135f0-7196-4c90-9a59-c71a3302372b")


### PR DESCRIPTION
## Summary

- Mechanisches sed-Replace `<<HASH>>` → `<<VERSION>>` in allen `.kicad_sch` und `.kicad_pcb`-Files.
- Keine elektrische oder Layout-Änderung — nur der Platzhalter-Name im Titelblock-Silkscreen.

## Phase 3 von 7 — Release-Konzept

- **Phase 1**: VERSIONING.md auf OE5XRX.github.io ([PR #3](https://github.com/OE5XRX/OE5XRX.github.io/pull/3))
- **Phase 2**: HW-Module-CI Workflow-Umstellung ([PR #4](https://github.com/OE5XRX/HW-Module-CI/pull/4)) — **muss zuerst gemergt sein**
- **Phase 3**: Diese PR (5 parallel — 1 pro Modul-Repo)

### Merge-Reihenfolge

1. HW-Module-CI#4 mergen
2. Direkt danach diese PR + die 4 Schwestern in den anderen Modul-Repos

Während des Zeitfensters zeigt das Titelblock kurzzeitig literal `<<HASH>>` (CI sucht nach `<<VERSION>>`, findet nichts, kein Substitut). Beim ersten `push:main` nach den Merges ist alles wieder konsistent.

## Test plan

- [ ] KiCad-Check CI grün (ERC + DRC unverändert)
- [ ] Nach Merge: einmal `workflow_dispatch` von „Create Debug Docs" und sichten dass im PDF-Schaltplan das Titelblock z.B. `BETA-<commit>` zeigt
- [ ] Erst danach `v1.0`-Release triggern (Phase 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)