### PR TITLE
feat: add Auto-Release wrapper workflow

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -1,0 +1,9 @@
+name: Auto-Release
+on:
+  workflow_dispatch:
+permissions:
+  contents: write
+jobs:
+  call:
+    uses: OE5XRX/HW-Module-CI/.github/workflows/auto-release.yaml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary

Adds a 10-line wrapper that exposes the Auto-Release workflow under *Actions → Auto-Release → Run workflow*. The actual release logic lives in [HW-Module-CI](https://github.com/OE5XRX/HW-Module-CI/blob/main/.github/workflows/auto-release.yaml).

Part of Phase 4 of the [release concept](https://oe5xrx.org/docs/remote-station/hardware/versioning/) — companion to all five other consumer-wrapper PRs.

## Test plan

- [ ] Workflow appears under Actions tab
- [ ] Manual dispatch from main runs; preflight + branch-guard + secret-precheck pass; compute-step fails with bootstrap-missing hint (no v1.0 exists yet — that's Phase 7)
- [ ] Manual dispatch from feature branch fails fast at branch-guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)