### PR TITLE
fix(sch): add title_block with <<VERSION>> to all 3 schematics

### DIFF
--- a/5V.kicad_sch
+++ b/5V.kicad_sch
@@ -4,6 +4,11 @@
 	(generator_version "9.0")
 	(uuid "7a59f0d0-0033-40bc-a1c4-1d4ae9f9acf2")
 	(paper "A4")
+	(title_block
+		(title "5V Buck Converter")
+		(rev "<<VERSION>>")
+		(company "Amateurfunkclub für Remote Stationen")
+	)
 	(lib_symbols
 		(symbol "Device:C"
 			(pin_numbers

--- a/PowerBoard.kicad_sch
+++ b/PowerBoard.kicad_sch
@@ -4,6 +4,11 @@
 	(generator_version "9.0")
 	(uuid "f29935ff-76ad-48dd-a9d8-f60fd99054e1")
 	(paper "A4")
+	(title_block
+		(title "Power")
+		(rev "<<VERSION>>")
+		(company "Amateurfunkclub für Remote Stationen")
+	)
 	(lib_symbols
 		(symbol "Connector_Generic:Conn_02x10_Row_Letter_First"
 			(pin_names

--- a/power_measurement.kicad_sch
+++ b/power_measurement.kicad_sch
@@ -4,6 +4,11 @@
 	(generator_version "9.0")
 	(uuid "dde21f85-3c5e-4e74-9187-b7b4b66850c3")
 	(paper "A4")
+	(title_block
+		(title "Power Measurement")
+		(rev "<<VERSION>>")
+		(company "Amateurfunkclub für Remote Stationen")
+	)
 	(lib_symbols
 		(symbol "Device:C"
 			(pin_numbers


### PR DESCRIPTION
## Why

PowerBoard's three .kicad_sch files have never had a title_block. Result: even after Phase 3 placeholder migration there was no `<<VERSION>>` token to substitute, and the schematic PDF rendered with a blank title-block area in the v1.0 release.

The other five HW-Module-* repos already follow this convention.

## What changes

Each of \`PowerBoard.kicad_sch\`, \`5V.kicad_sch\`, \`power_measurement.kicad_sch\` gets a title_block matching the existing project convention:

\`\`\`
(title_block
  (title "<sheet name>")
  (rev "<<VERSION>>")
  (company "Amateurfunkclub für Remote Stationen")
)
\`\`\`

Sheet-specific titles: *Power*, *5V Buck Converter*, *Power Measurement*.

## Versioning implications

This is a \`*.kicad_sch\` change with no \`*.kicad_pcb\` change → after merge, the Auto-Release workflow will classify this as a **Minor bump** (\`v1.0 → v1.1\`). That doubles as a nice end-to-end test of the Phase 4 Auto-Release path — the deploy of v1.1 should show the title block correctly on the schematic PDF.

## Test plan

- [x] kibot-check passes locally (ERC unchanged)
- [ ] Merge to main → CI green
- [ ] Dispatch Auto-Release workflow → expect v1.1 Minor tag
- [ ] v1.1 release-docs run → schematic PDF shows the title block + \`1.1\` as rev

🤖 Generated with [Claude Code](https://claude.com/claude-code)